### PR TITLE
Add MessageEvent

### DIFF
--- a/src/event/event_channel.js
+++ b/src/event/event_channel.js
@@ -1,4 +1,4 @@
-import { Friend, Group, MessageChain, MessageSource } from '../index.js';
+import { Friend, Group, GroupMessageEvent, MessageChain, MessageSource, SimpleMessageEvent } from '../index.js';
 
 /**
  * `EventChannel` 是 **Euphony** 完成事件操作的通道。
@@ -24,7 +24,14 @@ class EventChannel {
             }
             const contact = msg.chatType == 1 ? Friend.make(msg.peerUin, msg.peerUid) : (msg.chatType == 2 ? Group.make(msg.peerUin) : null);
             const source = new MessageSource(msg.msgId, contact);
-            eventChannel.call('receive-message', MessageChain.fromNative(msg.elements), source);
+            const message = MessageChain.fromNative(msg.elements);
+
+            if(msg.chatType == 2){
+                eventChannel.call('receive-message', new GroupMessageEvent(msg, message, source, msg.senderUin));
+            }else{
+                eventChannel.call('receive-message', new SimpleMessageEvent(msg, message, source));
+            }
+
         }
 
         euphonyNative.subscribeEvent('nodeIKernelMsgListener/onRecvMsg', onReceiveMessage);

--- a/src/event/group_message_event.js
+++ b/src/event/group_message_event.js
@@ -1,0 +1,26 @@
+import { SimpleMessageEvent } from '../index.js';
+
+/**
+ * `GroupMessageEvent` 代表消息接收到的事件。
+ * 
+ */
+class GroupMessageEvent extends SimpleMessageEvent {
+
+    #senderUin;
+
+    constructor(msgData, message, source, senderUin) {
+        super(msgData, message, source);
+        this.#senderUin = senderUin;
+    }
+
+    getSenderUin(){
+        return this.#senderUin;
+    }
+
+    getSenderAsMember(){
+        return this.getMessageSource().getContact().getMemberFromUin(this.#senderUin);
+    }
+
+}
+
+    export default GroupMessageEvent

--- a/src/event/simple_message_event.js
+++ b/src/event/simple_message_event.js
@@ -1,0 +1,56 @@
+/**
+ * `MessageEvent` 表示一个被触发的消息事件
+ * 
+ * @property { MessageChain } #messageChain 事件消息
+ * @property { MessageSource } #MessageSource 事件消息的来源
+ */
+class SimpleMessageEvent {
+
+    #msgData;
+
+    #messageChain;
+
+    #messageSource;
+
+    /**
+     * 仅供子类调用。
+     * 
+     * @param { MessageChain } messageChain 事件消息
+     * @param { MessageSource } messageSource 事件消息的来源。
+     */
+    constructor(msgdata, message, source) {
+        this.msgdata = msgdata;
+        this.#messageChain = message;
+        this.#messageSource = source;
+    }
+
+    /**
+     * 返回事件的消息
+     * 
+     * @returns { MessageChain }
+     */
+    getMessage() {
+        return this.#messageChain;
+    }
+
+    /**
+     * 返回该事件的 *消息来源*
+     * 
+     * @returns { MessageSource } 
+     */
+    getMessageSource() {
+        return this.#messageSource;
+    }
+
+    /**
+     * 返回未经处理的消息
+     * 
+     * @returns { any }
+     */
+    getMessageData() {
+        return this.#msgData;
+    }
+
+}
+
+export default SimpleMessageEvent

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,8 @@ import AtAll from './message/content/at_all.js';
 import Raw from './message/content/raw.js';
 
 import EventChannel from './event/event_channel.js';
+import SimpleMessageEvent from './event/simple_message_event.js';
+import GroupMessageEvent from './event/group_message_event.js';
 
 import Client from './client/client.js';
 
@@ -37,6 +39,8 @@ export {
     AtAll,
     Raw,
     EventChannel,
+    SimpleMessageEvent,
+    GroupMessageEvent,
     Client,
     Cache,
     ChatFuncBar


### PR DESCRIPTION
feat: eventchannel using messageevent to transmit data

EventChannel使用MessageEvent以便能传递更多数据。
使用方式：

```js
import { EventChannel, SimpleMessageEvent, GroupMessageEvent } from '../LiteLoaderQQNT-Euphony/src/index.js';
const eventChannel = EventChannel.withTriggers();
eventChannel.subscribeEvent('receive-message', (event) => {

    if(event instanceof GroupMessageEvent){
        // output sender qq id
        console.log(event.getSenderUin());
        // mute 60 sec
        event.getSenderAsMember().mute(60);
    }

    console.log(event.getMessage().contentToString());
    // if event is groupmessage, output group id
    console.log(event.getMessageSource().getContact().getId());
});
```